### PR TITLE
Lightweight selenium instance for testing purposes

### DIFF
--- a/sele_instance/Dockerfile
+++ b/sele_instance/Dockerfile
@@ -1,0 +1,9 @@
+FROM betaquick/selenium-node
+LABEL description="A kightweight selenium instance with port 4444 exposed"
+
+RUN npm install -g webdriver-manager \
+    && webdriver-manager update
+
+EXPOSE 4444
+
+ENTRYPOINT ["sh", "-c", "webdriver-manager start"]


### PR DESCRIPTION
This image is meant to be an easy way to run tests regardless of the environment
Updates to chrome sometimes leave `webdriver-manager` not pointing to the correct version